### PR TITLE
Initial demo version of libraries API with example implementations

### DIFF
--- a/src/proto-libs/api.h
+++ b/src/proto-libs/api.h
@@ -2,6 +2,7 @@
 #define MOTORS_API_H
 
 #include "stdbool.h"
+#include "stdint.h"
 
 /* Immutable attributes of a single motor connected via one of the supported protocols */
 typedef struct MotorAttributes MotorAttributes;
@@ -14,7 +15,7 @@ typedef enum {
 } CommunicationType;
 
 typedef struct {
-    int pins[4];
+    uint8_t pins[4];
 } GpioConnectionData;
 
 typedef struct {
@@ -48,26 +49,26 @@ typedef enum {
 
 
 /* Creates an opaque structure with motor attributes. */
-MotorAttributes* motor_init(int number_of_steps, MotorConnection connection);
+MotorAttributes* motor_init(uint16_t number_of_steps, MotorConnection connection);
 
 /* Deinitilizes motor and destroyes attributes structure */
 void motor_exit(MotorAttributes* attributes);
 
-MovementResult motor_move(MotorAttributes* attributes, int steps);
+MovementResult motor_move(MotorAttributes* attributes, uint16_t steps);
 
 /* how much time to wait between commands. Useful when commnuicating via i2c/spi */
-void motor_set_command_delay(MotorAttributes* attributes, int delay_ms);
+void motor_set_command_delay(MotorAttributes* attributes, uint32_t delay_ms);
 
 /* set gpio pins of max/min physical endstops, which trigger when motor reaches the limit position */
-void motor_set_max_enstop(MotorAttributes* attributes, int max_pin);
+void motor_set_max_enstop(MotorAttributes* attributes, uint16_t max_pin);
 
-void motor_set_min_enstop(MotorAttributes* attributes, int min_pin);
+void motor_set_min_enstop(MotorAttributes* attributes, uint16_t min_pin);
 
 // TODO: decide where to start counting the steps. From the left or from center?
 /* sets max/min positions for the motor */
-void motor_set_min_softlimit(MotorAttributes* attributes, int min_steps);
+void motor_set_min_softlimit(MotorAttributes* attributes, uint16_t min_steps);
 
-void motor_set_max_softlimit(MotorAttributes* attributes, int max_steps);
+void motor_set_max_softlimit(MotorAttributes* attributes, uint16_t max_steps);
 
 /* inverts default rotation direction */
 void motor_set_axis_inversion(MotorAttributes* attributes, bool invert);

--- a/src/proto-libs/api.h
+++ b/src/proto-libs/api.h
@@ -70,7 +70,8 @@ void motor_set_min_softlimit(MotorAttributes* attributes, int min_steps);
 void motor_set_max_softlimit(MotorAttributes* attributes, int max_steps);
 
 /* inverts default rotation direction */
-void motor_invert_direction(MotorAttributes* attributes, bool invert);
+void motor_set_axis_inversion(MotorAttributes* attributes, bool invert);
+
 
 /* TODO: decide how the upper layer can get the info about motor state. Is this method sutable here? */
 // MotorStatus get_current_status(MotorAttributes* attributes);

--- a/src/proto-libs/api.h
+++ b/src/proto-libs/api.h
@@ -1,0 +1,80 @@
+#ifndef MOTORS_API_H
+#define MOTORS_API_H
+
+#include "stdbool.h"
+
+/* Immutable attributes of a single motor connected via one of the supported protocols */
+typedef struct MotorAttributes MotorAttributes;
+
+/* Represents how the stepper is connected to the main board */
+typedef enum {
+    GPIO = 0,
+    SPI,
+    I2C
+} CommunicationType;
+
+typedef struct {
+    int pins[4];
+} GpioConnectionData;
+
+typedef struct {
+    char* spi_dev_name;
+} SpiConnectionData;
+
+typedef struct {
+    char* i2c_dev_name;
+} I2cConnectionData;
+
+/* Stores data required for one of the supported protocols */
+typedef union {
+    GpioConnectionData gpio;
+    SpiConnectionData spi;
+    I2cConnectionData i2c;
+} ConnectionAttributes;
+
+/* Stores data required to communicate with a motor/extension-board */
+typedef struct {
+    CommunicationType communicationType;
+    ConnectionAttributes connectionAttributes;
+} MotorConnection;
+
+/* Represent the status of movement invocation */
+typedef enum {
+    SUCCESS = 0,
+    MAX_REACHED,
+    MIN_REACHED,
+    COMMUNICATION_ERROR
+} MovementResult;
+
+
+/* Creates an opaque structure with motor attributes. */
+MotorAttributes* motor_init(int number_of_steps, MotorConnection connection);
+
+/* Deinitilizes motor and destroyes attributes structure */
+void motor_exit(MotorAttributes* attributes);
+
+MovementResult motor_move(MotorAttributes* attributes, int steps);
+
+/* how much time to wait between commands. Useful when commnuicating via i2c/spi */
+void motor_set_command_delay(MotorAttributes* attributes, int delay_ms);
+
+/* set gpio pins of max/min physical endstops, which trigger when motor reaches the limit position */
+void motor_set_max_enstop(MotorAttributes* attributes, int max_pin);
+
+void motor_set_min_enstop(MotorAttributes* attributes, int min_pin);
+
+// TODO: decide where to start counting the steps. From the left or from center?
+/* sets max/min positions for the motor */
+void motor_set_min_softlimit(MotorAttributes* attributes, int min_steps);
+
+void motor_set_max_softlimit(MotorAttributes* attributes, int max_steps);
+
+/* inverts default rotation direction */
+void motor_invert_direction(MotorAttributes* attributes, bool invert);
+
+/* TODO: decide how the upper layer can get the info about motor state. Is this method sutable here? */
+// MotorStatus get_current_status(MotorAttributes* attributes);
+
+// TODO: do we need preset movements - moving to specific position?
+
+#endif /* MOTORS_API_H */

--- a/src/proto-libs/internal.h
+++ b/src/proto-libs/internal.h
@@ -1,0 +1,43 @@
+#ifndef MOTORS_INTERNAL_H
+#define MOTORS_INTERNAL_H
+
+//TODO: do we need this import?
+#include "api.h"
+#include "stdint.h"
+
+typedef enum {
+    BACKWARD = 0,
+    FORWARD = 1
+} Direction;
+
+/* Contains mutable state for single motor */
+typedef struct {
+    Direction direction;
+    int current_steps;
+    int max_steps;
+    int min_steps;
+    uint32_t step_delay_us;
+    uint32_t last_step_time_us;
+
+    // TODO: we should reguaraly update these fields if they are present here.
+    /* bool max_triggered; */
+    /* bool min_triggered; */
+} MotorState;
+
+
+/* Contains attributes of a single motor.
+* Filled at the initialization phase.
+*/
+struct MotorAttributes {
+    MovementResult (* proto_specific_move)(MotorState* state, int steps);
+
+    MovementResult (* deactivate)(MotorAttributes* attributes);
+
+    //TODO: do we need a step angle and how it can be used?
+    int number_of_steps;
+    bool invert;
+    MotorConnection connection;
+    MotorState state;
+};
+
+#endif /* MOTORS_INTERNAL_H */

--- a/src/proto-libs/internal.h
+++ b/src/proto-libs/internal.h
@@ -13,9 +13,9 @@ typedef enum {
 /* Contains mutable state for single motor */
 typedef struct {
     Direction direction;
-    int current_steps;
-    int max_steps;
-    int min_steps;
+    uint16_t current_steps;
+    uint16_t max_steps;
+    uint16_t min_steps;
     uint32_t step_delay_us;
     uint32_t last_step_time_us;
 
@@ -25,7 +25,7 @@ typedef struct {
 } MotorState;
 
 
-typedef MovementResult (* motor_move_fn)(MotorState* state, int steps);
+typedef MovementResult (* motor_move_fn)(MotorState* state, uint16_t steps);
 typedef MovementResult (* motor_deactivate_fn)(MotorAttributes* attributes);
 
 /* Contains attributes of a single motor.
@@ -36,7 +36,7 @@ struct MotorAttributes {
     motor_deactivate_fn deactivate;
 
     //TODO: do we need a step angle and how it can be used?
-    int number_of_steps;
+    uint16_t number_of_steps;
     bool invert;
     MotorConnection connection;
     MotorState state;

--- a/src/proto-libs/internal.h
+++ b/src/proto-libs/internal.h
@@ -25,13 +25,15 @@ typedef struct {
 } MotorState;
 
 
+typedef MovementResult (* motor_move_fn)(MotorState* state, int steps);
+typedef MovementResult (* motor_deactivate_fn)(MotorAttributes* attributes);
+
 /* Contains attributes of a single motor.
 * Filled at the initialization phase.
 */
 struct MotorAttributes {
-    MovementResult (* proto_specific_move)(MotorState* state, int steps);
-
-    MovementResult (* deactivate)(MotorAttributes* attributes);
+    motor_move_fn move;
+    motor_deactivate_fn deactivate;
 
     //TODO: do we need a step angle and how it can be used?
     int number_of_steps;

--- a/src/proto-libs/lib-common-example.c
+++ b/src/proto-libs/lib-common-example.c
@@ -1,0 +1,37 @@
+#include <malloc.h>
+#include "internal.h"
+
+void motor_exit(MotorAttributes* attributes) {
+    // motor-specific way of deactivation (turn off gpio/ send stop commands etc.)
+    attributes->deactivate(attributes);
+    free(attributes);
+}
+
+
+MovementResult motor_move(MotorAttributes* attributes, int steps) {
+    // TODO: do we need common checks for all protocols like max/min positions here?
+    return attributes->proto_specific_move(&attributes->state, steps);
+}
+
+
+void motor_set_max_enstop(MotorAttributes* attributes, int max_pin) {
+    // TODO: create new struct in MotorAttributes with physical pins
+    // these pins should be checked on each step.
+}
+
+
+void motor_set_min_enstop(MotorAttributes* attributes, int min_pin) {}
+
+
+void motor_set_min_softlimit(MotorAttributes* attributes, int min_steps) {
+    attributes->state.min_steps = min_steps;
+}
+
+void motor_set_max_softlimit(MotorAttributes* attributes, int max_steps) {
+    attributes->state.max_steps = max_steps;
+}
+
+void motor_invert_direction(MotorAttributes* attributes, bool invert) {
+    attributes->invert = invert;
+}
+

--- a/src/proto-libs/lib-gpio-example.c
+++ b/src/proto-libs/lib-gpio-example.c
@@ -1,0 +1,69 @@
+#include "malloc.h"
+#include "internal.h"
+
+MotorState motor_state_init();
+
+MovementResult motor_gpio_move(MotorState* state, int steps);
+
+void motor_gpio_step(uint32_t step);
+
+void setOutputPins(int i);
+
+MotorAttributes* motor_init(int number_of_steps, MotorConnection connection) {
+    MotorAttributes* attributes = (MotorAttributes*) malloc(sizeof(MotorAttributes));
+    if (!attributes) {
+        // TODO: create unified way to handle errors.
+        return NULL;
+    }
+
+    attributes->proto_specific_move = &motor_gpio_move;
+    attributes->number_of_steps = number_of_steps;
+    attributes->invert = false;
+    attributes->connection = connection;
+    attributes->state = motor_state_init();
+}
+
+
+MovementResult motor_gpio_move(MotorState* state, int steps) {
+    if (state->direction == FORWARD && state->current_steps >= state->max_steps) {
+        return MAX_REACHED;
+    }
+    if (state->direction == BACKWARD && state->current_steps <= state->min_steps) {
+        return MIN_REACHED;
+    }
+
+    for (uint32_t i = 0; i < steps; i++) {
+        motor_gpio_step(i);
+        // sleep until the phase time passes
+    }
+    return SUCCESS;
+}
+
+MotorState motor_state_init() {
+    MotorState state;
+    state.current_steps = 0;
+
+    return state;
+}
+
+void motor_gpio_step(uint32_t step) {
+    switch (step & 0x3) {
+        case 0:    // 1010
+            setOutputPins(0b0101);
+            break;
+        case 1:    // 0110
+            setOutputPins(0b0110);
+            break;
+        case 2:    //0101
+            setOutputPins(0b1010);
+            break;
+        case 3:    //1001
+            setOutputPins(0b1001);
+            break;
+    }
+}
+
+void setOutputPins(int i) {
+    // setting multiple pins
+}
+


### PR DESCRIPTION
This pull request adds the initial demo version of the Libraries API. The API comprises of functions that enable users to interact with the motor and structures that represent its connection type and state. 

_The Protocol Library_ is a self-contained piece of code that implements all the logic required to communicate with a motor via a specific protocol, such as `UART` or `GPIO`. 

Library headers are divided into two parts: internal and external (API). The `MotorAttributes` structure is opaque, which hides most of the implementation details. 

Furthermore, two files, namely `lib-common-example.c` and `lib-gpio-example.c`, are included in this version. These files serve as templates for future implementations. The former is intended to be shared between different libraries, while the latter implements the functions in a protocol-specific manner.