### PR TITLE
fix: adjust invalid paths in cmake files

### DIFF
--- a/config_manager/CMakeLists.txt
+++ b/config_manager/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(config_manager C)
 
-set(SOURCES src/manager.c)
+set(SOURCES src/config_manager.c)
 
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/state_manager/CMakeLists.txt
+++ b/state_manager/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(state_manager C)
 
-set(SOURCES src/manager.c)
+set(SOURCES src/state_manager.c)
 
 add_executable(${PROJECT_NAME} ${SOURCES})


### PR DESCRIPTION
Project build was failing because of invalid filenames.