### PR TITLE
Manage yaml parser dependencies with Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(motorland C)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-#add_subdirectory(daemon)
-#add_subdirectory(state_manager)
-#add_subdirectory(config_manager)
+add_subdirectory(daemon)
+add_subdirectory(state_manager)
+add_subdirectory(config_manager)
 add_subdirectory(proto_libs)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Project for Embedded Systems course (Spring 2023)
 
 ## Development in Clion
 1. Choose module: `config_manager`, `daemon`, `gpiolib` or `state_manager`
-2. Click on build button (hammer)
+2. Run `Reset Cache and Reload Project` action in Clion
+3. Click on build button (hammer)
     - This will download all dependencies, compile and link them
     - Then it build the final executable. You can find it in `cmake-build-debug/bin/`

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ Project for Embedded Systems course (Spring 2023)
 [View link](https://drive.google.com/file/d/1G1Tt3iVF1fO9oixSPcnYtCqgEOOCVNLW/view)
 
 ![](docs/img/project_object_diagram.png)
+
+## Development in Clion
+1. Choose module: `config_manager`, `daemon`, `gpiolib` or `state_manager`
+2. Click on build button (hammer)
+    - This will download all dependencies, compile and link them
+    - Then it build the final executable. You can find it in `cmake-build-debug/bin/`

--- a/config_manager/CMakeLists.txt
+++ b/config_manager/CMakeLists.txt
@@ -6,8 +6,22 @@ file(GLOB_RECURSE SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.c")
 file(GLOB_RECURSE HEADERS "${CMAKE_CURRENT_LIST_DIR}/include/*.h")
 include_directories(include)
 
-find_library(LIBCYAML_LIBRARY cyaml)
-include_directories(/usr/local/include)
+include(lib_yaml_install.cmake)
+include(lib_cyaml_install.cmake)
 
 add_executable(${PROJECT_NAME} src/config_parser.c)
-target_link_libraries(${PROJECT_NAME} ${LIBCYAML_LIBRARY})
+
+target_sources(${PROJECT_NAME}
+        PRIVATE
+        ${SOURCES}
+        PUBLIC
+        ${HEADERS}
+        )
+
+target_include_directories(${PROJECT_NAME}
+        PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+        PRIVATE ${LIBYAML_INCLUDE_DIRS}
+        )
+
+target_link_libraries(${PROJECT_NAME} PRIVATE libcyaml libyaml)

--- a/config_manager/README.md
+++ b/config_manager/README.md
@@ -1,0 +1,4 @@
+# Config parser
+
+## How to run
+`./cmake-build-debug/bin/config_manager config_manager/examples/example.yaml`

--- a/config_manager/lib_cyaml_install.cmake
+++ b/config_manager/lib_cyaml_install.cmake
@@ -1,0 +1,32 @@
+include(ExternalProject)
+
+set(LIBCYAML_ROOT ${CMAKE_BINARY_DIR}/external)
+set(LIBCYAML_LIB_DIR ${LIBCYAML_ROOT}/lib)
+set(LIBCYAML_INCLUDE_DIRS ${LIBCYAML_ROOT}/include)
+set(TARGET_HOST arm-openipc-linux-musleabi)
+
+ExternalProject_Add(
+        libcyaml_external
+        PREFIX ${LIBCYAML_ROOT}
+        GIT_REPOSITORY "https://github.com/tlsa/libcyaml.git"
+        GIT_TAG "v1.4.1"
+        UPDATE_COMMAND ""
+        PATCH_COMMAND ""
+        BINARY_DIR ${LIBCYAML_ROOT}/src/libcyaml
+        SOURCE_DIR ${LIBCYAML_ROOT}/src/libcyaml
+        INSTALL_DIR ${LIBCYAML_ROOT}/bin
+        CONFIGURE_COMMAND ""
+        #        --prefix=${LIBCYAML_ROOT}
+        #        --enable-tools=no
+        #        --enable-bindings-python=no
+        #        --host=${TARGET_HOST}
+        #        --target=${TARGET_HOST}
+        BUILD_COMMAND ${MAKE} ARCH=arm CROSS_COMPILE=arm-openipc-linux-musleabi-
+        BUILD_BYPRODUCTS ${LIBCYAML_LIB_DIR}/libcyaml.a
+        INSTALL_COMMAND make PREFIX=${LIBCYAML_ROOT} install
+)
+
+add_library(libcyaml STATIC IMPORTED)
+set_target_properties(libcyaml PROPERTIES IMPORTED_LOCATION ${LIBCYAML_LIB_DIR}/libcyaml.a)
+add_dependencies(libcyaml libcyaml_external)
+

--- a/config_manager/lib_cyaml_install.cmake
+++ b/config_manager/lib_cyaml_install.cmake
@@ -16,11 +16,6 @@ ExternalProject_Add(
         SOURCE_DIR ${LIBCYAML_ROOT}/src/libcyaml
         INSTALL_DIR ${LIBCYAML_ROOT}/bin
         CONFIGURE_COMMAND ""
-        #        --prefix=${LIBCYAML_ROOT}
-        #        --enable-tools=no
-        #        --enable-bindings-python=no
-        #        --host=${TARGET_HOST}
-        #        --target=${TARGET_HOST}
         BUILD_COMMAND ${MAKE} ARCH=arm CROSS_COMPILE=arm-openipc-linux-musleabi-
         BUILD_BYPRODUCTS ${LIBCYAML_LIB_DIR}/libcyaml.a
         INSTALL_COMMAND make PREFIX=${LIBCYAML_ROOT} install

--- a/config_manager/lib_yaml_install.cmake
+++ b/config_manager/lib_yaml_install.cmake
@@ -1,0 +1,36 @@
+include(ExternalProject)
+
+set(LIBYAML_ROOT ${CMAKE_BINARY_DIR}/external)
+set(LIBYAML_LIB_DIR ${LIBYAML_ROOT}/lib)
+set(LIBYAML_INCLUDE_DIRS ${LIBYAML_ROOT}/include)
+set(TARGET_HOST arm-openipc-linux-musleabi)
+
+ExternalProject_Add(
+        libyaml_external
+        PREFIX ${LIBCYAML_ROOT}
+        GIT_REPOSITORY "https://github.com/yaml/libyaml.git"
+        GIT_TAG "0.2.5"
+        UPDATE_COMMAND ""
+        PATCH_COMMAND ""
+        BINARY_DIR ${LIBYAML_ROOT}/src/libyaml
+        SOURCE_DIR ${LIBYAML_ROOT}/src/libyaml
+        INSTALL_DIR ${LIBYAML_ROOT}/bin
+        CONFIGURE_COMMAND <SOURCE_DIR>/configure
+        --prefix=${LIBYAML_ROOT}
+        --host=${TARGET_HOST}
+        --target=${TARGET_HOST}
+        BUILD_COMMAND ${MAKE} ARCH=arm CROSS_COMPILE=arm-openipc-linux-musleabi-
+        BUILD_BYPRODUCTS ${LIBYAML_LIB_DIR}/libyaml.a
+)
+
+ExternalProject_Add_Step(libyaml_external
+        bootstrap
+        COMMAND ./bootstrap --host=${TARGET_HOST} --target=${TARGET_HOST}
+        DEPENDEES download
+        DEPENDERS configure
+        WORKING_DIRECTORY ${LIBYAML_ROOT}/src/libyaml)
+
+add_library(libyaml STATIC IMPORTED)
+set_target_properties(libyaml PROPERTIES IMPORTED_LOCATION ${LIBYAML_LIB_DIR}/libyaml.a)
+add_dependencies(libyaml libyaml_external)
+

--- a/config_manager/src/config_manager.c
+++ b/config_manager/src/config_manager.c
@@ -1,7 +1,7 @@
 #pragma "once"
 
-#include "../include/config_manager.h"
-#include "../include/config_parser.h"
+#include "config_manager.h"
+#include "config_parser.h"
 
 enum {
     FILE_OPEN_FAILED,

--- a/config_manager/src/config_parser.c
+++ b/config_manager/src/config_parser.c
@@ -55,9 +55,14 @@ int config_parser_parse_config(char *filepath, ConfigWrapper **wrapper) {
     return cyaml_load_file(filepath, &config, &configs_schema, (void **) wrapper, NULL);
 }
 
-int main() {
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+    	printf("Error: File path argument is required.\n");
+    	return 1;
+    }
+
+    char *filepath = argv[1];
     ConfigWrapper *wrapper;
-    char *filepath = "/home/viacheslav/CLionProjects/motorland_fork/config_manager/examples/example.yaml";
     int err = cyaml_load_file(filepath, &config, &configs_schema, (cyaml_data_t **) &wrapper, NULL);
 
     printf("Error: %d\n", err);


### PR DESCRIPTION
- Add build instructions to README.md
- All dependencies are downloaded and built automatically
- Pass path to example yaml config via cli args